### PR TITLE
Fixing broken link to cosmos sdk on main page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ description: >-
 
 ## Getting Started
 
-> The Provenance Blockchain is based on the [Cosmos SDK ](https://docs.cosmos.network/v0.42/)and the [Tendermint](https://docs.tendermint.com/master/) blockchain application platforms.  It is useful to have a basic understanding of both these technologies prior to reading the Provenance Blockchain documentation. Refer to the [Cosmos SDK basics documentation](https://docs.cosmos.network/v0.42/intro/overview.html) and the [Tendermint overview](https://docs.tendermint.com/master/introduction/what-is-tendermint.html#) for more information.
+> The Provenance Blockchain is based on the [Cosmos SDK ](https://docs.cosmos.network/v0.42/)and the [Tendermint](https://docs.tendermint.com/master/) blockchain application platforms.  It is useful to have a basic understanding of both these technologies prior to reading the Provenance Blockchain documentation. Refer to the [Cosmos SDK basics documentation](https://docs.cosmos.network/master/intro/overview.html) and the [Tendermint overview](https://docs.tendermint.com/master/introduction/what-is-tendermint.html#) for more information.
 
 Read about the Provenance Blockchain and financial services:
 


### PR DESCRIPTION
The link to the Cosmos SDK docs on the main page is broken (was referring to 4.2 docs).