### PR TITLE
Add a section to the name module docs with info about name restrictions.

### DIFF
--- a/modules/name-module.md
+++ b/modules/name-module.md
@@ -32,6 +32,21 @@ type NameRecord struct {
 }
 ```
 
+### Normalization
+
+Name records are normalized before being processed for creation or query.  Each component of the name must conform to a standard set of rules.  The sha256 of the normalized value is used internally for comparision purposes.
+
+1. Names are always stored and compared using a lower case form or a hash derived from this normalized form.
+2. Unicode values that are not graphic, lower case, or digits are considered invalid.
+3. A single occurance of the hyphen-minus character is allowed unless the value conforms to a valid UUID.
+```value: -
+HYPHEN-MINUS
+Unicode: U+002D, UTF-8: 2D
+```
+4. Each component of the name is subject to a length of 2 to 32 characters (inclusive). These limits are configurable in the module [parameters](./05_params.md).
+5. A maximum of 16 components for a name (levels in the heirarchy) is also enforced and configurable in the module parameters.
+6. Leading and trailing spaces are always trimmed off of names for consistency during processing and evaluation.
+
 ### Creation of Root Names
 
 As every name hierarchy depends on the name above it for permissioning and control, the root names present a problem with no parent to enforce their management.  Because of this inception problem root names must be created in the genesis of the blockchain or through a governance proposal process.

--- a/modules/name-module.md
+++ b/modules/name-module.md
@@ -43,7 +43,7 @@ Name records are normalized before being processed for creation or query.  Each 
 HYPHEN-MINUS
 Unicode: U+002D, UTF-8: 2D
 ```
-4. Each component of the name is subject to a length of 2 to 32 characters (inclusive). These limits are configurable in the module [parameters](./05_params.md).
+4. Each component of the name is subject to a length of 2 to 32 characters (inclusive). These limits are configurable in the module parameters.
 5. A maximum of 16 components for a name (levels in the heirarchy) is also enforced and configurable in the module parameters.
 6. Leading and trailing spaces are always trimmed off of names for consistency during processing and evaluation.
 

--- a/modules/name-module.md
+++ b/modules/name-module.md
@@ -43,7 +43,7 @@ Name records are normalized before being processed for creation or query.  Each 
 HYPHEN-MINUS
 Unicode: U+002D, UTF-8: 2D
 ```
-4. Each component of the name is subject to a length of 2 to 32 characters (inclusive). These limits are configurable in the module parameters.
+4. Each component of the name is restricted to a length of 2 to 32 characters (inclusive). These limits are configurable in the module parameters.
 5. A maximum of 16 components for a name (levels in the heirarchy) is also enforced and configurable in the module parameters.
 6. Leading and trailing spaces are always trimmed off of names for consistency during processing and evaluation.
 


### PR DESCRIPTION

Updates the name module page to include info about what is and isn't allowed in names.

This is copied from the `x/name/spec/01_concepts.md` page in the provenance repo.