### PR TITLE
Fix broken links to cosmos docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ description: >-
 
 ## Getting Started
 
-> The Provenance Blockchain is based on the [Cosmos SDK ](https://docs.cosmos.network/v0.42/)and the [Tendermint](https://docs.tendermint.com/master/) blockchain application platforms. It is useful to have a basic understanding of both these technologies prior to reading the Provenance Blockchain documentation. Refer to the [Cosmos SDK basics documentation](https://docs.cosmos.network/v0.42/intro/overview.html) and the [Tendermint overview](https://docs.tendermint.com/master/introduction/what-is-tendermint.html#) for more information.
+> The Provenance Blockchain is based on the [Cosmos SDK ](https://docs.cosmos.network/main/)and the [Tendermint](https://docs.tendermint.com/master/) blockchain application platforms. It is useful to have a basic understanding of both these technologies prior to reading the Provenance Blockchain documentation. Refer to the [Cosmos SDK basics documentation](https://docs.cosmos.network/main/intro/overview.html) and the [Tendermint overview](https://docs.tendermint.com/master/introduction/what-is-tendermint.html#) for more information.
 
 Read about the Provenance Blockchain and financial services:
 

--- a/basics/accounts.md
+++ b/basics/accounts.md
@@ -6,7 +6,7 @@ description: Understanding the Provenance Blockchain accounts system.
 
 ## Account Definition
 
-On Provenance Blockchain an [account](https://docs.cosmos.network/v0.41/basics/accounts.html) designates a pair of _public key_ `PubKey` and _private key_ `PrivKey`. The `PubKey` is used to generate an `address` which is used to identify users \(among other parties\) on the blockchain. `Addresses` are also associated with [`message`s](https://docs.cosmos.network/master/building-modules/messages-and-queries.html#messages) to identify the sender of the `message`. The `PrivKey` is used to generate [digital signatures](https://docs.cosmos.network/master/basics/query-lifecycle.html#signatures) to prove that an `address`associated with the `PrivKey` approved of a given `message`.
+On Provenance Blockchain an [account](https://docs.cosmos.network/main/basics/accounts.html) designates a pair of _public key_ `PubKey` and _private key_ `PrivKey`. The `PubKey` is used to generate an `address` which is used to identify users \(among other parties\) on the blockchain. `Addresses` are also associated with [`message`s](https://docs.cosmos.network/main/building-modules/messages-and-queries.html#messages) to identify the sender of the `message`. The `PrivKey` is used to generate [digital signatures](https://docs.cosmos.network/main/basics/query-lifecycle.html#signatures) to prove that an `address`associated with the `PrivKey` approved of a given `message`.
 
 ### Addresses <a id="addresses"></a>
 
@@ -28,7 +28,7 @@ Provenance Blockchain testnet Bech32 addresses begin with `tp` whereas mainnet a
 _**A key pair and it's corresponding Bec32 address that exists outside of Provenance Blockchain \(say in a wallet\) is not a Provenance Blockchain account until Hash has been transferred to the Bech32 address.**_
 {% endhint %}
 
-For example, using `provenanced` we can generate a local key pair and store it in the default [Keyring](https://docs.cosmos.network/master/basics/accounts.html#keyring):
+For example, using `provenanced` we can generate a local key pair and store it in the default [Keyring](https://docs.cosmos.network/main/basics/accounts.html#keyring):
 
 ```bash
 provenanced --testnet keys add my_test_key  

--- a/basics/anatomy-of-a-provenance-application.md
+++ b/basics/anatomy-of-a-provenance-application.md
@@ -6,7 +6,7 @@ description: >-
 
 # Anatomy of the Provenance Blockchain Application
 
-In it's simplest form, Provenance Blockchain is an [application-specific blockchain](https://docs.cosmos.network/master/intro/why-app-specific.html) build on the [Cosmos SDK.](https://docs.cosmos.network/master/intro/overview.html)  Thus, the anatomy described in this section is a derivative of the [Cosmos SDK Anatomy of an SDK ](https://docs.cosmos.network/master/basics/app-anatomy.html)[Application](https://docs.cosmos.network/master/basics/app-anatomy.html) document.
+In it's simplest form, Provenance Blockchain is an [application-specific blockchain](https://docs.cosmos.network/main/intro/why-app-specific.html) build on the [Cosmos SDK.](https://docs.cosmos.network/main/intro/overview.html)  Thus, the anatomy described in this section is a derivative of the [Cosmos SDK Anatomy of an SDK ](https://docs.cosmos.network/main/basics/app-anatomy.html)[Application](https://docs.cosmos.network/main/basics/app-anatomy.html) document.
 
 The Provenance Blockchain SDK \(build upon the Cosmos SDK\) enables developers to build modules that implement the business logic of a financial services blockchain. In other words, SDK modules implement the bulk of the logic of the blockchains, while the core does the wiring and enables modules to be composed together. The end goal is to build a robust ecosystem of open-source SDK modules, making it increasingly easier to build complex blockchain applications.
 
@@ -26,7 +26,7 @@ The **Tendermint BFT State Machine Replication** component \(again, compiled int
 
 The **Provenance Blockchain SDK**, built on top of the Cosmos SDK, manages a state-machine and key-value store.  The Provenanced SDK [includes base modules from the Cosmos SDK](../modules/inherited-modules.md) as well as custom modules like [Metadata](../modules/metadata-module.md) and [Marker](../modules/marker-module.md) for financial-services related functionality.  The Provenance Blockchain SDK component communicates with [Tendermint using the ABCI](https://docs.tendermint.com/master/spec/abci/#abci).  ABCI is a Tendermint construct and serves as the interface between Tendermint \(a state-machine replication engine\) and the Provenance Blockchain application \(the actual state machine and blockchain implementation\).
 
-The `provenanced` binary encapsulates the Provenance Blockchain SDK \(and inheritied Cosmos SDK\) and Tendermint engine.  [Cosmovisor](https://docs.cosmos.network/master/run-node/cosmovisor.html) is a small process manager around `provenanced` that monitors the governance module via stdout to see if there's a chain upgrade proposal coming in. If it see a proposal that gets approved it can be run manually or automatically to download the new code, stop the node, run the migration script, replace the node binary, and start with the new genesis file.
+The `provenanced` binary encapsulates the Provenance Blockchain SDK \(and inheritied Cosmos SDK\) and Tendermint engine.  [Cosmovisor](https://docs.cosmos.network/main/run-node/cosmovisor.html) is a small process manager around `provenanced` that monitors the governance module via stdout to see if there's a chain upgrade proposal coming in. If it see a proposal that gets approved it can be run manually or automatically to download the new code, stop the node, run the migration script, replace the node binary, and start with the new genesis file.
 
 #### Node Resources
 

--- a/basics/gas-and-fees.md
+++ b/basics/gas-and-fees.md
@@ -6,10 +6,10 @@ description: Provenance Blockchain transaction gas and fees.
 
 ## Gas Definition
 
-On Provenance Blockchain, [`gas` is a special unit that is used to track the consumption of resources ](https://docs.cosmos.network/master/basics/gas-fees.html)during transaction execution. `gas` is typically consumed whenever read and writes are made to a Provenance Blockchain state store, but it can also be consumed if expensive computation needs to be done. It serves two main purposes:
+On Provenance Blockchain, [`gas` is a special unit that is used to track the consumption of resources ](https://docs.cosmos.network/main/basics/gas-fees.html)during transaction execution. `gas` is typically consumed whenever read and writes are made to a Provenance Blockchain state store, but it can also be consumed if expensive computation needs to be done. It serves two main purposes:
 
-* Make sure blocks are not consuming too many resources and will be finalized. This is implemented by default via the [block gas meter](https://docs.cosmos.network/master/basics/accounts.html#block-gas-meter).
-* Prevent spam and abuse from end-users. `gas` consumed during [`message`](https://docs.cosmos.network/master/building-modules/messages-and-queries.html#messages) execution is typically priced, resulting in a `fee` \(`fees = gas * gas-prices`\). `fees` generally have to be paid by the sender of the `message`.
+* Make sure blocks are not consuming too many resources and will be finalized. This is implemented by default via the [block gas meter](https://docs.cosmos.network/main/basics/accounts.html#block-gas-meter).
+* Prevent spam and abuse from end-users. `gas` consumed during [`message`](https://docs.cosmos.network/main/building-modules/messages-and-queries.html#messages) execution is typically priced, resulting in a `fee` \(`fees = gas * gas-prices`\). `fees` generally have to be paid by the sender of the `message`.
 
 ## Gas Calculations
 

--- a/basics/query-lifecycle.md
+++ b/basics/query-lifecycle.md
@@ -4,7 +4,7 @@ description: Querying blockchain state.
 
 # Query Lifecycle
 
-A [**query**](https://docs.cosmos.network/master/building-modules/messages-and-queries.html#queries) is a request for information made by end-users of applications through an interface and processed by a full-node. Users can query information about the network, the blockchain itself, and blockchain state directly from the blockchain's stores or modules.  Queries differ from transactions in that they do not require consensus to be processed and therefore do not change state.  Queries can be fully handled by a single full-node.
+A [**query**](https://docs.cosmos.network/main/building-modules/messages-and-queries.html#queries) is a request for information made by end-users of applications through an interface and processed by a full-node. Users can query information about the network, the blockchain itself, and blockchain state directly from the blockchain's stores or modules.  Queries differ from transactions in that they do not require consensus to be processed and therefore do not change state.  Queries can be fully handled by a single full-node.
 
 Refer to [Using Provenanced](../using-provenance/) for hands-on queries.
 
@@ -18,11 +18,11 @@ The main interface for an application is the command-line interface. Users conne
 
 #### gRPC
 
-Users and applications can submit queries using [gRPC](https://grpc.io/) requests to a [gRPC server](https://docs.cosmos.network/master/core/grpc_rest.html#grpc-server). The `provenanced` daemon process is bundled with gRPC endpoints by default. The endpoints are defined as [Protocol Buffers ](https://developers.google.com/protocol-buffers)service methods inside `.proto` files, written in Protobuf's own language-agnostic interface definition language \(IDL\). The Protobuf ecosystem developed tools for code-generation from `*.proto` files into various languages. These tools allow to build gRPC clients easily.
+Users and applications can submit queries using [gRPC](https://grpc.io/) requests to a [gRPC server](https://docs.cosmos.network/main/core/grpc_rest.html#grpc-server). The `provenanced` daemon process is bundled with gRPC endpoints by default. The endpoints are defined as [Protocol Buffers ](https://developers.google.com/protocol-buffers)service methods inside `.proto` files, written in Protobuf's own language-agnostic interface definition language \(IDL\). The Protobuf ecosystem developed tools for code-generation from `*.proto` files into various languages. These tools allow to build gRPC clients easily.
 
 [gRPCurl](https://github.com/fullstorydev/grpcurl) is an excellent command-line tool that can be used to interact with blockchain gRPC endpoints.
 
 #### REST
 
-Users and applications can submit queries through HTTP Requests to a [REST server](https://docs.cosmos.network/master/core/grpc_rest.html#rest-server). The REST server is fully auto-generated from Protobuf services, using [gRPC-gateway](https://github.com/grpc-ecosystem/grpc-gateway).
+Users and applications can submit queries through HTTP Requests to a [REST server](https://docs.cosmos.network/main/core/grpc_rest.html#rest-server). The REST server is fully auto-generated from Protobuf services, using [gRPC-gateway](https://github.com/grpc-ecosystem/grpc-gateway).
 

--- a/basics/transaction-lifecycle.md
+++ b/basics/transaction-lifecycle.md
@@ -6,7 +6,7 @@ description: Submitting transactions to the blockchain.
 
 ## Transaction Flow
 
-When users want to interact with the blockchain and make state changes \(e.g. sending coins\), they create transactions. [Transactions](https://docs.cosmos.network/master/core/transactions.html) originate via some user application and trigger state changes within a blockchain module \(i.e. the bank module and transferring coin\). Each of a transaction's `Msg`s must be signed using the private key associated with the appropriate [account](accounts.md)\(s\) before the transaction is broadcast to the network. A transaction must then be included in a block, validated, and approved by the network through the consensus process.
+When users want to interact with the blockchain and make state changes \(e.g. sending coins\), they create transactions. [Transactions](https://docs.cosmos.network/main/core/transactions.html) originate via some user application and trigger state changes within a blockchain module \(i.e. the bank module and transferring coin\). Each of a transaction's `Msg`s must be signed using the private key associated with the appropriate [account](accounts.md)\(s\) before the transaction is broadcast to the network. A transaction must then be included in a block, validated, and approved by the network through the consensus process.
 
 ![](../.gitbook/assets/image%20%289%29.png)
 
@@ -17,7 +17,7 @@ The Transaction Submission Flow diagram illustrates how a user application trans
   * Signing the `Tx Msg` using a key pair from a wallet or Key Management facility
   * Determining gas and fee costs
   * Submitting the signed `Tx Msg` to a blockchain node using the CLI or `gRPC.`
-* The `Tx Msg` is received by the blockchain node, again a device running the `provenanced` daemon process.  The `Tx Msg` is placed into the `Mempool Cache` for [pre-processing validation](https://docs.cosmos.network/master/basics/tx-lifecycle.html#addition-to-mempool).  These pre-process checks include checking that the appropriate addresses are not empty, enforcing field checks like non-negative numbers, or other logic specified in the module.
+* The `Tx Msg` is received by the blockchain node, again a device running the `provenanced` daemon process.  The `Tx Msg` is placed into the `Mempool Cache` for [pre-processing validation](https://docs.cosmos.network/main/basics/tx-lifecycle.html#addition-to-mempool).  These pre-process checks include checking that the appropriate addresses are not empty, enforcing field checks like non-negative numbers, or other logic specified in the module.
   * If the `Tx Msg` is invalid it is rejected and handled by the User Application.  Nothing is added to the blockchain.
 * Once the `Tx Msg` passes pre-processing in `Check Tx` it is submitted to the `Mempool` where is is broadcast to other peers and eligible for inclusion in a block.  The `Mempool` serves the purpose of keeping track of transactions seen by all full-nodes. Full-nodes keep the `Mempool Cache` of the last transactions they have seen, as a first line of defense to prevent replay attacks. `CheckTx` is responsible for identifying and rejecting replayed transactions.
 * The **Consensus Engine** uses a Consensus Round Structure where a **Proposer Node** is selected in turn.  Thus, each round a new Proposer Node is designated to proposed the new block.  The Proposer Node selects transactions from its Mempool for inclusion in the proposed block.  Note that each Node has an up-to-date copy of the Mempool communicated via node gossip.
@@ -40,7 +40,7 @@ The important components of this flow are:
 * The blockchain will broadcast events related to transaction processing that can be consumed by the User Application.
 
 {% hint style="info" %}
-The [Cosmos documentation also provides a Transaction Lifecycle walk through ](https://docs.cosmos.network/master/basics/tx-lifecycle.html)with detailed information about the Mempool, State Changes, Consensus Rounds, and more.  
+The [Cosmos documentation also provides a Transaction Lifecycle walk through ](https://docs.cosmos.network/main/basics/tx-lifecycle.html)with detailed information about the Mempool, State Changes, Consensus Rounds, and more.  
 {% endhint %}
 
 ### Transaction Endpoints
@@ -53,13 +53,13 @@ The main interface for an application is the command-line interface. Users conne
 
 #### gRPC
 
-Users and applications can submit transactions using [gRPC](https://grpc.io/) requests to a [gRPC server](https://docs.cosmos.network/master/core/grpc_rest.html#grpc-server). The `provenanced` daemon process is bundled with gRPC endpoints by default. The endpoints are defined as [Protocol Buffers ](https://developers.google.com/protocol-buffers)service methods inside `.proto` files, written in Protobuf's own language-agnostic interface definition language \(IDL\). The Protobuf ecosystem developed tools for code-generation from `*.proto` files into various languages. These tools allow to build gRPC clients easily.
+Users and applications can submit transactions using [gRPC](https://grpc.io/) requests to a [gRPC server](https://docs.cosmos.network/main/core/grpc_rest.html#grpc-server). The `provenanced` daemon process is bundled with gRPC endpoints by default. The endpoints are defined as [Protocol Buffers ](https://developers.google.com/protocol-buffers)service methods inside `.proto` files, written in Protobuf's own language-agnostic interface definition language \(IDL\). The Protobuf ecosystem developed tools for code-generation from `*.proto` files into various languages. These tools allow to build gRPC clients easily.
 
 [gRPCurl](https://github.com/fullstorydev/grpcurl) is an excellent command-line tool that can be used to interact with blockchain gRPC endpoints.
 
 #### REST
 
-Users and applications can submit transactions through HTTP Requests to a [REST server](https://docs.cosmos.network/master/core/grpc_rest.html#rest-server). The REST server is fully auto-generated from Protobuf services, using [gRPC-gateway](https://github.com/grpc-ecosystem/grpc-gateway).
+Users and applications can submit transactions through HTTP Requests to a [REST server](https://docs.cosmos.network/main/core/grpc_rest.html#rest-server). The REST server is fully auto-generated from Protobuf services, using [gRPC-gateway](https://github.com/grpc-ecosystem/grpc-gateway).
 
 [Refer to Using Provenanced](../using-provenance/) for hands-on transaction submission.
 

--- a/blockchain/basics/accounts.md
+++ b/blockchain/basics/accounts.md
@@ -6,7 +6,7 @@ description: Understanding the Provenance Blockchain accounts system.
 
 ## Overview
 
-On Provenance Blockchain, an [account](https://docs.cosmos.network/v0.41/basics/accounts.html) designates a pair of _public key_ `PubKey` and _private key_ `PrivKey`. The `PubKey` is used to generate an `address` that is used to identify users \(among other parties\) on the blockchain. `Addresses` are also associated with `messages` to identify the sender of the `message`. The `PrivKey` is used to generate [digital signatures](https://docs.cosmos.network/master/basics/query-lifecycle.html#signatures) to prove that an `address`associated with the `PrivKey` approved of a given `message`.
+On Provenance Blockchain, an [account](https://docs.cosmos.network/main/basics/accounts.html) designates a pair of _public key_ `PubKey` and _private key_ `PrivKey`. The `PubKey` is used to generate an `address` that is used to identify users \(among other parties\) on the blockchain. `Addresses` are also associated with `messages` to identify the sender of the `message`. The `PrivKey` is used to generate [digital signatures](https://docs.cosmos.network/main/basics/query-lifecycle.html#signatures) to prove that an `address`associated with the `PrivKey` approved of a given `message`.
 
 ### Addresses <a id="addresses"></a>
 
@@ -32,7 +32,7 @@ _**A key pair and it's corresponding Bec32 address that exist outside of Provena
 To follow along with this section refer to [Installing Provenance Blockchain](../running-a-node/) to install the `provenanced` binary.
 {% endhint %}
 
-For example, using `provenanced` we can generate a local key pair and store it in the default [Keyring](https://docs.cosmos.network/master/basics/accounts.html#keyring):
+For example, using `provenanced` we can generate a local key pair and store it in the default [Keyring](https://docs.cosmos.network/main/basics/accounts.html#keyring):
 
 ```bash
 provenanced --testnet keys add my_test_key  

--- a/blockchain/basics/anatomy-of-a-provenance-application.md
+++ b/blockchain/basics/anatomy-of-a-provenance-application.md
@@ -6,7 +6,7 @@ description: >-
 
 # Anatomy of the Provenance Blockchain Application
 
-In it's simplest form, Provenance Blockchain is an [application-specific blockchain](https://docs.cosmos.network/master/intro/why-app-specific.html) built on the [Cosmos SDK.](https://docs.cosmos.network/master/intro/overview.html) Thus, the anatomy described in this section is a derivative of the Cosmos [Anatomy of an SDK Application](https://docs.cosmos.network/master/basics/app-anatomy.html) document.
+In it's simplest form, Provenance Blockchain is an [application-specific blockchain](https://docs.cosmos.network/main/intro/why-app-specific.html) built on the [Cosmos SDK.](https://docs.cosmos.network/main/intro/overview.html) Thus, the anatomy described in this section is a derivative of the Cosmos [Anatomy of an SDK Application](https://docs.cosmos.network/main/basics/app-anatomy.html) document.
 
 The Provenance Blockchain SDK enables developers to build modules that implement the business logic of a financial services blockchain. In other words, SDK modules implement the bulk of the logic of the blockchain, while the core does the wiring and enables modules to be composed together. The end goal is to build a robust ecosystem of open-source SDK modules, making it increasingly easier to build complex blockchain applications.
 
@@ -26,7 +26,7 @@ The **Tendermint BFT State Machine Replication** component (again, compiled into
 
 The **Provenance Blockchain SDK**, built on top of the Cosmos SDK, manages a state-machine and key-value store. The Provenanced SDK [includes base modules from the Cosmos SDK](../../modules/inherited-modules.md) as well as custom modules like [Metadata](../../modules/metadata-module.md) and [Marker](../../modules/marker-module.md) for financial-services related functionality. The Provenance Blockchain SDK component communicates with [Tendermint using the ABCI](https://docs.tendermint.com/master/spec/abci/#abci). ABCI is a Tendermint construct and serves as the interface between Tendermint (a state-machine replication engine) and the Provenance Blockchain application (the actual state machine and blockchain implementation).
 
-The `provenanced` binary encapsulates the Provenance Blockchain SDK (and inheritied Cosmos SDK) and Tendermint engine. [Cosmovisor](https://docs.cosmos.network/master/run-node/cosmovisor.html) is a small process manager around `provenanced` that monitors the governance module via stdout to see if there's a chain upgrade proposal coming in. If it sees a proposal that gets approved it can be run manually or automatically to download the new code, stop the node, run the migration script, replace the node binary, and start with the new genesis file.
+The `provenanced` binary encapsulates the Provenance Blockchain SDK (and inheritied Cosmos SDK) and Tendermint engine. [Cosmovisor](https://docs.cosmos.network/main/run-node/cosmovisor.html) is a small process manager around `provenanced` that monitors the governance module via stdout to see if there's a chain upgrade proposal coming in. If it sees a proposal that gets approved it can be run manually or automatically to download the new code, stop the node, run the migration script, replace the node binary, and start with the new genesis file.
 
 #### Node Resources
 

--- a/blockchain/basics/gas-and-fees.md
+++ b/blockchain/basics/gas-and-fees.md
@@ -20,7 +20,7 @@ Fees are determined by the gas limits and gas prices transactions provide, where
 
 When adding transactions to the [mempool or gossipping transactions](transaction-lifecycle.md), nodes check if the transaction's gas prices, which are determined by the provided fees, meet the node's minimum gas prices.
 
-Thus, on Provenance Blockchain, [`gas` is a special unit that is used to track the consumption of resources ](https://docs.cosmos.network/master/basics/gas-fees.html)during transaction execution to ensure:
+Thus, on Provenance Blockchain, [`gas` is a special unit that is used to track the consumption of resources ](https://docs.cosmos.network/main/basics/gas-fees.html)during transaction execution to ensure:
 
 * Blocks are not consuming too many resources and will be finalized.
 * No spam or abuse from end-users.

--- a/blockchain/basics/query-lifecycle.md
+++ b/blockchain/basics/query-lifecycle.md
@@ -4,7 +4,7 @@ description: Querying blockchain state.
 
 # Query Lifecycle
 
-A [**query**](https://docs.cosmos.network/master/building-modules/messages-and-queries.html#queries) is a request for information made by end-users of applications through an interface and processed by a full-node. Users can query information about the network, the blockchain itself, and blockchain state directly from the blockchain's stores or modules.  Queries differ from transactions in that they do not require consensus to be processed and therefore do not change state.  Queries can be fully handled by a single full-node.
+A [**query**](https://docs.cosmos.network/main/building-modules/messages-and-queries.html#queries) is a request for information made by end-users of applications through an interface and processed by a full-node. Users can query information about the network, the blockchain itself, and blockchain state directly from the blockchain's stores or modules.  Queries differ from transactions in that they do not require consensus to be processed and therefore do not change state.  Queries can be fully handled by a single full-node.
 
 Refer to [Using Provenanced](../using-provenance/) for hands-on queries.
 
@@ -18,11 +18,11 @@ The main interface for an application is the command-line interface. Users conne
 
 #### gRPC
 
-Users and applications can submit queries using [gRPC](https://grpc.io/) requests to a [gRPC server](https://docs.cosmos.network/master/core/grpc_rest.html#grpc-server). The `provenanced` daemon process is bundled with gRPC endpoints by default. The endpoints are defined as [Protocol Buffers ](https://developers.google.com/protocol-buffers)service methods inside `.proto` files, written in Protobuf's own language-agnostic interface definition language \(IDL\). The Protobuf ecosystem developed tools for code-generation from `*.proto` files into various languages. These tools allow to build gRPC clients easily.
+Users and applications can submit queries using [gRPC](https://grpc.io/) requests to a [gRPC server](https://docs.cosmos.network/main/core/grpc_rest.html#grpc-server). The `provenanced` daemon process is bundled with gRPC endpoints by default. The endpoints are defined as [Protocol Buffers ](https://developers.google.com/protocol-buffers)service methods inside `.proto` files, written in Protobuf's own language-agnostic interface definition language \(IDL\). The Protobuf ecosystem developed tools for code-generation from `*.proto` files into various languages. These tools allow to build gRPC clients easily.
 
 [gRPCurl](https://github.com/fullstorydev/grpcurl) is an excellent command-line tool that can be used to interact with blockchain gRPC endpoints.
 
 #### REST
 
-Users and applications can submit queries through HTTP Requests to a [REST server](https://docs.cosmos.network/master/core/grpc_rest.html#rest-server). The REST server is fully auto-generated from Protobuf services, using [gRPC-gateway](https://github.com/grpc-ecosystem/grpc-gateway).
+Users and applications can submit queries through HTTP Requests to a [REST server](https://docs.cosmos.network/main/core/grpc_rest.html#rest-server). The REST server is fully auto-generated from Protobuf services, using [gRPC-gateway](https://github.com/grpc-ecosystem/grpc-gateway).
 

--- a/blockchain/basics/transaction-lifecycle.md
+++ b/blockchain/basics/transaction-lifecycle.md
@@ -6,7 +6,7 @@ description: Submitting transactions to the blockchain.
 
 ## Transaction Flow
 
-When users want to interact with the blockchain and make state changes (e.g. sending coins), they create transactions. [Transactions](https://docs.cosmos.network/master/core/transactions.html) originate via some user application and trigger state changes within a blockchain module (i.e. the bank module and transferring coin). Each of a transaction's `Msg`s must be signed using the private key associated with the appropriate [account](accounts.md)(s) before the transaction is broadcast to the network. A transaction must then be included in a block, validated, and approved by the network through the consensus process.
+When users want to interact with the blockchain and make state changes (e.g. sending coins), they create transactions. [Transactions](https://docs.cosmos.network/main/core/transactions.html) originate via some user application and trigger state changes within a blockchain module (i.e. the bank module and transferring coin). Each of a transaction's `Msg`s must be signed using the private key associated with the appropriate [account](accounts.md)(s) before the transaction is broadcast to the network. A transaction must then be included in a block, validated, and approved by the network through the consensus process.
 
 ![Transaction Submission Flow](<../../.gitbook/assets/image (9).png>)
 
@@ -17,7 +17,7 @@ The Transaction Submission Flow diagram illustrates how a user application trans
   * Signing the `Tx Msg` using a key pair from a wallet or Key Management facility
   * Setting gas and fee parameters
   * Submitting the signed `Tx Msg` to a blockchain node using the CLI or `gRPC.`
-* The `Tx Msg` is received by a blockchain node, again a device running the `provenanced` daemon process.  The `Tx Msg` is placed into the `Mempool Cache` for [pre-processing validation](https://docs.cosmos.network/master/basics/tx-lifecycle.html#addition-to-mempool).  These pre-process checks include checking that the appropriate addresses are not empty, enforcing field checks like non-negative numbers, or other logic specified in the module.
+* The `Tx Msg` is received by a blockchain node, again a device running the `provenanced` daemon process.  The `Tx Msg` is placed into the `Mempool Cache` for [pre-processing validation](https://docs.cosmos.network/main/basics/tx-lifecycle.html#addition-to-mempool).  These pre-process checks include checking that the appropriate addresses are not empty, enforcing field checks like non-negative numbers, or other logic specified in the module.
   * If the `Tx Msg` is invalid it is rejected and handled by the User Application.  Nothing is added to the blockchain.
 * Once the `Tx Msg` passes pre-processing in `Check Tx` it is submitted to the `Mempool` where is is broadcast to other blockchain peers and eligible for inclusion in a block.  The `Mempool` serves the purpose of keeping track of transactions seen by all full-nodes. Full-nodes keep the `Mempool Cache` of the last transactions they have seen, as a first line of defense to prevent replay attacks. `CheckTx` is responsible for identifying and rejecting replayed transactions.
 * The **Consensus Engine** uses a Consensus Round Structure where a **Proposer Node** is selected in turn.  Thus, each round a new Proposer Node is designated to propose the new block.  The Proposer Node selects transactions from its Mempool for inclusion in the proposed block.  Note that each Node has an up-to-date copy of the Mempool communicated via node gossip.
@@ -40,7 +40,7 @@ The important components of this flow are:
 * The blockchain will broadcast events related to transaction processing that can be consumed by the User Application.
 
 {% hint style="info" %}
-The [Cosmos documentation also provides a Transaction Lifecycle walk through ](https://docs.cosmos.network/master/basics/tx-lifecycle.html)with detailed information about the Mempool, State Changes, Consensus Rounds, and more. &#x20;
+The [Cosmos documentation also provides a Transaction Lifecycle walk through ](https://docs.cosmos.network/main/basics/tx-lifecycle.html)with detailed information about the Mempool, State Changes, Consensus Rounds, and more. &#x20;
 {% endhint %}
 
 ### Transaction Endpoints
@@ -53,12 +53,12 @@ The main interface for an application is the command-line interface. Users conne
 
 #### gRPC
 
-Users and applications can submit transactions using [gRPC](https://grpc.io/) requests to a [gRPC server](https://docs.cosmos.network/master/core/grpc\_rest.html#grpc-server). The `provenanced` daemon process is bundled with gRPC endpoints by default. The endpoints are defined as [Protocol Buffers ](https://developers.google.com/protocol-buffers)service methods inside `.proto` files, written in Protobuf's own language-agnostic interface definition language (IDL). The Protobuf ecosystem developed tools for code-generation from `*.proto` files into various languages. These tools allow to build gRPC clients easily.
+Users and applications can submit transactions using [gRPC](https://grpc.io/) requests to a [gRPC server](https://docs.cosmos.network/main/core/grpc\_rest.html#grpc-server). The `provenanced` daemon process is bundled with gRPC endpoints by default. The endpoints are defined as [Protocol Buffers ](https://developers.google.com/protocol-buffers)service methods inside `.proto` files, written in Protobuf's own language-agnostic interface definition language (IDL). The Protobuf ecosystem developed tools for code-generation from `*.proto` files into various languages. These tools allow to build gRPC clients easily.
 
 [gRPCurl](https://github.com/fullstorydev/grpcurl) is an excellent command-line tool that can be used to interact with blockchain gRPC endpoints.
 
 #### REST
 
-Users and applications can submit transactions through HTTP Requests to a [REST server](https://docs.cosmos.network/master/core/grpc\_rest.html#rest-server). The REST server is fully auto-generated from Protobuf services, using [gRPC-gateway](https://github.com/grpc-ecosystem/grpc-gateway).
+Users and applications can submit transactions through HTTP Requests to a [REST server](https://docs.cosmos.network/main/core/grpc\_rest.html#rest-server). The REST server is fully auto-generated from Protobuf services, using [gRPC-gateway](https://github.com/grpc-ecosystem/grpc-gateway).
 
 [Refer to Using Provenanced](../using-provenance/) for hands-on transaction submission.

--- a/blockchain/introduction/major-components.md
+++ b/blockchain/introduction/major-components.md
@@ -30,7 +30,7 @@ Financial transactions often consist of on-chain and client-side parts. For fina
 
 ## Provenance Blockchain Node
 
-A Provenance Blockchain Node is a daemon process (`provenanced`) [Full-Node Client](https://docs.cosmos.network/v0.41/core/node.html) implementation and is the core process that runs the Provenance Blockchain. This process runs the state-machine, starting from a genesis file, and connects to peers on the network running the same client to receive and relay transactions, block proposals and signatures. Participants in the network run this process to initialize their state-machine, connect with other full-nodes and update their state-machine as new blocks come in. The blockchain full-node presents itself as the `provenanced` binary.
+A Provenance Blockchain Node is a daemon process (`provenanced`) [Full-Node Client](https://docs.cosmos.network/main/core/node.html) implementation and is the core process that runs the Provenance Blockchain. This process runs the state-machine, starting from a genesis file, and connects to peers on the network running the same client to receive and relay transactions, block proposals and signatures. Participants in the network run this process to initialize their state-machine, connect with other full-nodes and update their state-machine as new blocks come in. The blockchain full-node presents itself as the `provenanced` binary.
 
 Nodes in the network include:
 
@@ -42,17 +42,17 @@ Nodes in the network include:
 
 ### Cosmovisor
 
-[Cosmovisor](https://docs.cosmos.network/master/run-node/cosmovisor.html) is a small process manager around the Provenance Blockchain daemon process (`provenanced`) that monitors the [governance module](../../ecosystem/governance/) for [upgrade](../../ecosystem/governance/software-upgrade-proposal.md) proposals. Approved upgrade proposals can be run manually or automatically to download the new code, stop the node, run the migration script, replace the node binary, and start with the a genesis file.
+[Cosmovisor](https://docs.cosmos.network/main/run-node/cosmovisor.html) is a small process manager around the Provenance Blockchain daemon process (`provenanced`) that monitors the [governance module](../../ecosystem/governance/) for [upgrade](../../ecosystem/governance/software-upgrade-proposal.md) proposals. Approved upgrade proposals can be run manually or automatically to download the new code, stop the node, run the migration script, replace the node binary, and start with the a genesis file.
 
 ### Modules
 
-[Modules](https://docs.cosmos.network/v0.41/building-modules/intro.html) define the Provenance Blockchain logic. Provenance Blockchain is composed of modules from the Cosmos SDK and custom modules to support value markers and the [Contract Execution Environment](../../p8e/overview/). Modules provide core functionality that blockchain applications need, including a [boilerplate implementation of the ABCI](https://docs.cosmos.network/v0.41/core/baseapp.html) to communicate with the underlying consensus engine, a [multistore](https://docs.cosmos.network/v0.41/core/store.html#multistore) to persist state, a [server](https://docs.cosmos.network/v0.41/core/node.html) to form a full-node, and [interfaces](https://docs.cosmos.network/v0.41/interfaces/interfaces-intro.html) to handle queries. Modules implement the bulk of the logic of financial service applications and the core does the wiring to enable modules to be composed together.
+[Modules](https://docs.cosmos.network/main/building-modules/intro.html) define the Provenance Blockchain logic. Provenance Blockchain is composed of modules from the Cosmos SDK and custom modules to support value markers and the [Contract Execution Environment](../../p8e/overview/). Modules provide core functionality that blockchain applications need, including a [boilerplate implementation of the ABCI](https://docs.cosmos.network/main/core/baseapp.html) to communicate with the underlying consensus engine, a [multistore](https://docs.cosmos.network/main/core/store.html#multistore) to persist state, a [server](https://docs.cosmos.network/main/core/node.html) to form a full-node, and [interfaces](https://docs.cosmos.network/main/interfaces/interfaces-intro.html) to handle queries. Modules implement the bulk of the logic of financial service applications and the core does the wiring to enable modules to be composed together.
 
 Modules can be seen as little state-machines within the state-machine. They generally define a subset of the state using one or more key-value stores and message types.
 
 ### Key Ring
 
-To interact with the `provenanced` daemon, and by extension the node, a keyring that holds the private/public key pairs used to interact with a node must be established. For example, a validator key needs to be set up before running the blockchain node so that blocks can be correctly signed. The private key can be stored in different locations, called "backends", such as a file, an [HSM](https://en.wikipedia.org/wiki/Hardware\_security\_module), or the operating system's own key storage. [Refer to the Cosmos keyring documentation for more information.](https://docs.cosmos.network/master/run-node/keyring.html)
+To interact with the `provenanced` daemon, and by extension the node, a keyring that holds the private/public key pairs used to interact with a node must be established. For example, a validator key needs to be set up before running the blockchain node so that blocks can be correctly signed. The private key can be stored in different locations, called "backends", such as a file, an [HSM](https://en.wikipedia.org/wiki/Hardware\_security\_module), or the operating system's own key storage. [Refer to the Cosmos keyring documentation for more information.](https://docs.cosmos.network/main/run-node/keyring.html)
 
 ### Genesis
 
@@ -60,7 +60,7 @@ Before running a node the chain is initialized via a genesis file. A default Pro
 
 ### Interacting with a Node
 
-There are multiple ways to interact with a node: using the CLI, using gRPC, or using the REST endpoints. With a running node, the `provenanced` daemon process can be used as a CLI. The CLI provides functionality for signing and submitting transactions, querying, key and key ring management, as well as Module interaction. [Refer to the Cosmos Interacting with the Node documentation for more information.](https://docs.cosmos.network/master/run-node/interact-node.html)
+There are multiple ways to interact with a node: using the CLI, using gRPC, or using the REST endpoints. With a running node, the `provenanced` daemon process can be used as a CLI. The CLI provides functionality for signing and submitting transactions, querying, key and key ring management, as well as Module interaction. [Refer to the Cosmos Interacting with the Node documentation for more information.](https://docs.cosmos.network/main/run-node/interact-node.html)
 
 ## Smart Contracts
 

--- a/blockchain/running-a-node/running-a-node-1/join-provenance-testnet/README.md
+++ b/blockchain/running-a-node/running-a-node-1/join-provenance-testnet/README.md
@@ -49,7 +49,7 @@ Once the node has synced it is joined to the Provenance Blockchain testnet. Note
 
 ## Setting Up a New Node
 
-Unlike the Quick Start instructions, this section describes setting up a new full node from scratch with [Cosmovisor](https://docs.cosmos.network/master/run-node/cosmovisor.html) and better configuration options. This section effectively configures and starts a Provenance Blockchain full node.
+Unlike the Quick Start instructions, this section describes setting up a new full node from scratch with [Cosmovisor](https://docs.cosmos.network/main/run-node/cosmovisor.html) and better configuration options. This section effectively configures and starts a Provenance Blockchain full node.
 
 Before starting this section, be sure the prerequisites have been installed as described in [Installing Provenance Blockchain](../../#prerequisites).
 

--- a/blockchain/using-provenance/tx-command.md
+++ b/blockchain/using-provenance/tx-command.md
@@ -132,7 +132,7 @@ Once confirmed, the transaction will be signed using the private key portion of 
 ```
 
 {% hint style="info" %}
-Gas, gas, and more gas: notice that the transaction response includes `gas_wanted` and a `gas_used` values.  When we submitted our transaction we indicated we were willing to pay 65,000 units of gas \(`--gas 65000`\) at 1 nhash per unit \(`--gas-prices 1nhash`\).  The actual cost of the transaction was 61,579 units of gas at our 1 nhash per unit price.  Refer to the [Cosmos Introduction to Gas and Fees](https://docs.cosmos.network/master/basics/gas-fees.html) and the [Provenance Blockchain Gas and Fees ](../basics/gas-and-fees.md)section.
+Gas, gas, and more gas: notice that the transaction response includes `gas_wanted` and a `gas_used` values.  When we submitted our transaction we indicated we were willing to pay 65,000 units of gas \(`--gas 65000`\) at 1 nhash per unit \(`--gas-prices 1nhash`\).  The actual cost of the transaction was 61,579 units of gas at our 1 nhash per unit price.  Refer to the [Cosmos Introduction to Gas and Fees](https://docs.cosmos.network/main/basics/gas-fees.html) and the [Provenance Blockchain Gas and Fees ](../basics/gas-and-fees.md)section.
 {% endhint %}
 
 Of note in the transaction response are:

--- a/introduction/major-components.md
+++ b/introduction/major-components.md
@@ -30,7 +30,7 @@ Financial transactions often consist of on-chain and side-chain parts. For finan
 
 ## Provenance Blockchain Node
 
-A Provenance Blockchain Node is a daemon process \(`provenanced`\) [Full-Node Client](https://docs.cosmos.network/v0.41/core/node.html) implementation.  It is the core process that runs the Provenance Blockchain. It runs the state-machine, starting from a genesis file, and connects to peers on the network running the same client to receive and relay transactions, block proposals and signatures.  Participants in the network run this process to initialize their state-machine, connect with other full-nodes and update their state-machine as new blocks come in.  The blockchain full-node presents itself as the `provenanced` binary.
+A Provenance Blockchain Node is a daemon process \(`provenanced`\) [Full-Node Client](https://docs.cosmos.network/main/core/node.html) implementation.  It is the core process that runs the Provenance Blockchain. It runs the state-machine, starting from a genesis file, and connects to peers on the network running the same client to receive and relay transactions, block proposals and signatures.  Participants in the network run this process to initialize their state-machine, connect with other full-nodes and update their state-machine as new blocks come in.  The blockchain full-node presents itself as the `provenanced` binary.
 
 Nodes in the network include:
 
@@ -42,17 +42,17 @@ Nodes in the network include:
 
 ### Cosmovisor
 
-[Cosmovisor](https://docs.cosmos.network/master/run-node/cosmovisor.html) is a small process manager around the Provenance Blockchain daemon process \(`provenanced`\) that monitors the governance module for upgrade proposals. Approved upgrade proposals can be run manually or automatically to download the new code, stop the node, run the migration script, replace the node binary, and start with the a genesis file.
+[Cosmovisor](https://docs.cosmos.network/main/run-node/cosmovisor.html) is a small process manager around the Provenance Blockchain daemon process \(`provenanced`\) that monitors the governance module for upgrade proposals. Approved upgrade proposals can be run manually or automatically to download the new code, stop the node, run the migration script, replace the node binary, and start with the a genesis file.
 
 ### Modules
 
-[Modules](https://docs.cosmos.network/v0.41/building-modules/intro.html) define the Provenance Blockchain logic. Provenance Blockchain is composed of modules from the Cosmos SDK and custom modules to support value markers and the client-side Contract Execution Environment.  Modules provide core functionality blockchain applications needs like a [boilerplate implementation of the ABCI](https://docs.cosmos.network/v0.41/core/baseapp.html) to communicate with the underlying consensus engine, a [multistore](https://docs.cosmos.network/v0.41/core/store.html#multistore) to persist state, a [server](https://docs.cosmos.network/v0.41/core/node.html) to form a full-node and [interfaces](https://docs.cosmos.network/v0.41/interfaces/interfaces-intro.html) to handle queries.  Modules implement the bulk of the logic of financial service applications and  the core does the wiring and enables modules to be composed together. 
+[Modules](https://docs.cosmos.network/main/building-modules/intro.html) define the Provenance Blockchain logic. Provenance Blockchain is composed of modules from the Cosmos SDK and custom modules to support value markers and the client-side Contract Execution Environment.  Modules provide core functionality blockchain applications needs like a [boilerplate implementation of the ABCI](https://docs.cosmos.network/main/core/baseapp.html) to communicate with the underlying consensus engine, a [multistore](https://docs.cosmos.network/main/core/store.html#multistore) to persist state, a [server](https://docs.cosmos.network/main/core/node.html) to form a full-node and [interfaces](https://docs.cosmos.network/main/interfaces/interfaces-intro.html) to handle queries.  Modules implement the bulk of the logic of financial service applications and  the core does the wiring and enables modules to be composed together. 
 
 Modules can be seen as little state-machines within the state-machine. They generally define a subset of the state using one or more key-value stores and message types.
 
 ### Key Ring
 
-To interact with the `provenanced` daemon, and by extension the node, a keyring that holds the private/public key pairs used to interact with a node must be established. For example, a validator key needs to be set up before running the blockchain node so that blocks can be correctly signed. The private key can be stored in different locations, called "backends", such as a file or the operating system's own key storage.  [Refer to the Cosmos keyring documentation for more information.](https://docs.cosmos.network/master/run-node/keyring.html)
+To interact with the `provenanced` daemon, and by extension the node, a keyring that holds the private/public key pairs used to interact with a node must be established. For example, a validator key needs to be set up before running the blockchain node so that blocks can be correctly signed. The private key can be stored in different locations, called "backends", such as a file or the operating system's own key storage.  [Refer to the Cosmos keyring documentation for more information.](https://docs.cosmos.network/main/run-node/keyring.html)
 
 ### Genesis
 
@@ -60,7 +60,7 @@ Before running a node the chain is initialized via a genesis file.  A default Pr
 
 ### Interacting with a Node
 
-There are multiple ways to interact with a node: using the CLI, using gRPC or using the REST endpoints.  With a running node, the `provenanced` daemon process can be used as a CLI.  The CLI provides functionality for signing and submitting transactions, querying, key and key ring management, as well as Module interaction.  [Refer to the Cosmos Interacting with the Node documentation for more information.](https://docs.cosmos.network/master/run-node/interact-node.html)
+There are multiple ways to interact with a node: using the CLI, using gRPC or using the REST endpoints.  With a running node, the `provenanced` daemon process can be used as a CLI.  The CLI provides functionality for signing and submitting transactions, querying, key and key ring management, as well as Module interaction.  [Refer to the Cosmos Interacting with the Node documentation for more information.](https://docs.cosmos.network/main/run-node/interact-node.html)
 
 ## Smart Contracts
 

--- a/modules/inherited-modules.md
+++ b/modules/inherited-modules.md
@@ -8,18 +8,18 @@ The Cosmos SDK, on which the Provenance Blockchain application is based, provide
 
 The Provenance Blockchain inherits the following core Cosmos SDK Modules:
 
-* [**Auth**](https://docs.cosmos.network/master/modules/auth/) - Authentication of accounts and transactions.
-* \*\*\*\*[**Bank**](https://docs.cosmos.network/master/modules/bank/) - Token transfer functionalities.
-* \*\*\*\*[**Capability**](https://docs.cosmos.network/master/modules/capability/) - Object capability implementation.
-* \*\*\*\*[**Crisis**](https://docs.cosmos.network/master/modules/crisis/) - Halting the blockchain under certain circumstances \(e.g. if an invariant is broken\).
-* \*\*\*\*[**Distribution**](https://docs.cosmos.network/master/modules/distribution/) - Fee distribution, and staking token provision distribution.
-* \*\*\*\*[**Evidence**](https://docs.cosmos.network/master/modules/evidence/) - Evidence handling for double signing, misbehavior, etc.
-* \*\*\*\*[**Governance**](https://docs.cosmos.network/master/modules/gov/) - On-chain proposals and voting.
-* \*\*\*\*[**IBC**](https://docs.cosmos.network/master/modules/ibc/) - IBC protocol for transport, authentication and ordering.
-* \*\*\*\*[**IBC Transfer**](https://docs.cosmos.network/master/modules/ibc/) - Cross-chain fungible token transfer implementation through IBC.
-* \*\*\*\*[**Mint**](https://docs.cosmos.network/master/modules/mint/) - Creation of new units of staking token \(currently set to 0% inflation\).
-* \*\*\*\*[**Params**](https://docs.cosmos.network/master/modules/params/) - Globally available parameter store for modules that supports Governance based configuration and management.
-* \*\*\*\*[**Slashing**](https://docs.cosmos.network/master/modules/slashing/) - Validator punishment mechanisms.
-* \*\*\*\*[**Staking**](https://docs.cosmos.network/master/modules/staking/) - Proof-of-Stake layer for public blockchains.
-* \*\*\*\*[**Upgrade**](https://docs.cosmos.network/master/modules/upgrade/) - Software upgrades handling and coordination.
+* [**Auth**](https://docs.cosmos.network/main/modules/auth/) - Authentication of accounts and transactions.
+* \*\*\*\*[**Bank**](https://docs.cosmos.network/main/modules/bank/) - Token transfer functionalities.
+* \*\*\*\*[**Capability**](https://docs.cosmos.network/main/modules/capability/) - Object capability implementation.
+* \*\*\*\*[**Crisis**](https://docs.cosmos.network/main/modules/crisis/) - Halting the blockchain under certain circumstances \(e.g. if an invariant is broken\).
+* \*\*\*\*[**Distribution**](https://docs.cosmos.network/main/modules/distribution/) - Fee distribution, and staking token provision distribution.
+* \*\*\*\*[**Evidence**](https://docs.cosmos.network/main/modules/evidence/) - Evidence handling for double signing, misbehavior, etc.
+* \*\*\*\*[**Governance**](https://docs.cosmos.network/main/modules/gov/) - On-chain proposals and voting.
+* \*\*\*\*[**IBC**](https://docs.cosmos.network/main/modules/ibc/) - IBC protocol for transport, authentication and ordering.
+* \*\*\*\*[**IBC Transfer**](https://docs.cosmos.network/main/modules/ibc/) - Cross-chain fungible token transfer implementation through IBC.
+* \*\*\*\*[**Mint**](https://docs.cosmos.network/main/modules/mint/) - Creation of new units of staking token \(currently set to 0% inflation\).
+* \*\*\*\*[**Params**](https://docs.cosmos.network/main/modules/params/) - Globally available parameter store for modules that supports Governance based configuration and management.
+* \*\*\*\*[**Slashing**](https://docs.cosmos.network/main/modules/slashing/) - Validator punishment mechanisms.
+* \*\*\*\*[**Staking**](https://docs.cosmos.network/main/modules/staking/) - Proof-of-Stake layer for public blockchains.
+* \*\*\*\*[**Upgrade**](https://docs.cosmos.network/main/modules/upgrade/) - Software upgrades handling and coordination.
 

--- a/running-a-node/running-a-node-1/join-provenance-testnet.md
+++ b/running-a-node/running-a-node-1/join-provenance-testnet.md
@@ -45,7 +45,7 @@ Once the node has synced it is joined to the Provenance Blockchain testnet.  Not
 
 ## Setting Up a New Node
 
-Unlike the Quick Start instructions, this section describes setting up a new full node from scratch with [Cosmovisor](https://docs.cosmos.network/master/run-node/cosmovisor.html) and better configuration options.  This section effectively configures and starts a Provenance Blockchain full node.
+Unlike the Quick Start instructions, this section describes setting up a new full node from scratch with [Cosmovisor](https://docs.cosmos.network/main/run-node/cosmovisor.html) and better configuration options.  This section effectively configures and starts a Provenance Blockchain full node.
 
 Before starting this section, be sure the prerequisites have been installed as described in [Installing Provenance Blockchain](../#prerequisites).
 

--- a/using-provenance/tx-command.md
+++ b/using-provenance/tx-command.md
@@ -132,7 +132,7 @@ Once confirmed, the transaction will be signed using the private key portion of 
 ```
 
 {% hint style="info" %}
-Gas, gas, and more gas: notice that the transaction response includes `gas_wanted` and a `gas_used` values.  When we submitted our transaction we indicated we were willing to pay 65,000 units of gas \(`--gas 65000`\) at 1 nhash per unit \(`--gas-prices 1nhash`\).  The actual cost of the transaction was 61,579 units of gas at our 1 nhash per unit price.  Refer to the [Cosmos Introduction to Gas and Fees](https://docs.cosmos.network/master/basics/gas-fees.html) and the [Provenance Blockchain Gas and Fees ](../basics/gas-and-fees.md)section.
+Gas, gas, and more gas: notice that the transaction response includes `gas_wanted` and a `gas_used` values.  When we submitted our transaction we indicated we were willing to pay 65,000 units of gas \(`--gas 65000`\) at 1 nhash per unit \(`--gas-prices 1nhash`\).  The actual cost of the transaction was 61,579 units of gas at our 1 nhash per unit price.  Refer to the [Cosmos Introduction to Gas and Fees](https://docs.cosmos.network/main/basics/gas-fees.html) and the [Provenance Blockchain Gas and Fees ](../basics/gas-and-fees.md)section.
 {% endhint %}
 
 Of note in the transaction response are:


### PR DESCRIPTION
## Problem
- Many links to cosmos docs were returning a 404.
- Most were linked to old versions that are no longer available
- Some were linked to master, which as been renamed to main

## Solution
- Replaced `docs.cosmos.network/(0.4\d|master)` with ` docs.cosmos.network/main`